### PR TITLE
fix broken API: project as parameter, deprecated method usages, black list as a project-service

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -33,6 +33,7 @@
               />
     <applicationService serviceImplementation="com.thinklint.PhpLintConfigurationManager"/>
     <projectService serviceImplementation="com.thinklint.PhpLintProjectConfiguration"/>
+    <projectService serviceImplementation="com.thinklint.PhpLintBlackList"/>
     <localInspection language="PHP"
                      shortName="PhpLintInspection"
                      enabledByDefault="false"

--- a/src/com/thinklint/PhpLintConfigurable.java
+++ b/src/com/thinklint/PhpLintConfigurable.java
@@ -60,7 +60,7 @@ public class PhpLintConfigurable extends QualityToolProjectConfigurableForm {
 
     @NotNull
     protected QualityToolConfigurationComboBox createConfigurationComboBox() {
-        return new PhpLintConfigurationComboBox();
+        return new PhpLintConfigurationComboBox(myProject);
     }
 }
 

--- a/src/com/thinklint/PhpLintConfiguration.java
+++ b/src/com/thinklint/PhpLintConfiguration.java
@@ -1,5 +1,6 @@
 package com.thinklint;
 
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.ArrayUtil;
 import com.intellij.util.xmlb.annotations.Attribute;
@@ -8,6 +9,7 @@ import com.thinklint.PhpLintConfigurationManager;
 import com.intellij.util.xmlb.annotations.Attribute;
 import com.intellij.util.xmlb.annotations.Transient;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Created by zenus on 2015/8/1.
@@ -52,7 +54,7 @@ public class  PhpLintConfiguration implements QualityToolConfiguration {
         this.myTimeoutMs = timeout;
     }
 
-    public String getPresentableName() {
+    public String getPresentableName(@Nullable Project project) {
         return this.getId();
     }
 
@@ -84,6 +86,6 @@ public class  PhpLintConfiguration implements QualityToolConfiguration {
     }
 
     public int compareTo(@NotNull QualityToolConfiguration o) {
-        return !(o instanceof PhpLintConfiguration)?1:(StringUtil.equals(this.getPresentableName(), "Local")?-1:(StringUtil.equals(o.getPresentableName(), "Local")?1:StringUtil.compare(this.getPresentableName(), o.getPresentableName(), false)));
+        return !(o instanceof PhpLintConfiguration)?1:(StringUtil.equals(this.getPresentableName(null), "Local")?-1:(StringUtil.equals(o.getPresentableName(null), "Local")?1:StringUtil.compare(this.getPresentableName(null), o.getPresentableName(null), false)));
     }
 }

--- a/src/com/thinklint/PhpLintConfigurationComboBox.java
+++ b/src/com/thinklint/PhpLintConfigurationComboBox.java
@@ -8,6 +8,7 @@ import com.thinklint.PhpLintConfiguration;
 import com.thinklint.PhpLintConfigurationManager;
 import com.jetbrains.php.ui.PhpUiUtil;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -17,7 +18,8 @@ import java.util.List;
  * Created by zenus on 2015/8/1.
  */
 public class PhpLintConfigurationComboBox extends QualityToolConfigurationComboBox<PhpLintConfiguration> {
-    public PhpLintConfigurationComboBox() {
+    public PhpLintConfigurationComboBox(@Nullable Project project) {
+        super(project);
     }
 
     @NotNull

--- a/src/com/thinklint/PhpLintOptionsPanel.java
+++ b/src/com/thinklint/PhpLintOptionsPanel.java
@@ -18,7 +18,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.table.JBTable;
 import com.intellij.util.Consumer;
 import com.jetbrains.php.config.interpreters.PhpInterpreter;
-import com.jetbrains.php.config.interpreters.PhpInterpretersManager;
+import com.jetbrains.php.config.interpreters.PhpInterpretersManagerImpl;
 import com.jetbrains.php.run.remote.PhpRemoteInterpreterManager;
 import com.jetbrains.php.tools.quality.QualityToolValidationException;
 import com.thinklint.PhpLintConfiguration;
@@ -93,7 +93,7 @@ public class PhpLintOptionsPanel {
 
         try {
             PhpLintConfiguration e = (PhpLintConfiguration)PhpLintProjectConfiguration.getInstance(project).findSelectedConfiguration(project);
-            return e != null && !StringUtil.isEmpty(e.getInterpreterId())?PhpInterpretersManager.getInstance().findInterpreterById(e.getInterpreterId()):null;
+            return e != null && !StringUtil.isEmpty(e.getInterpreterId())? PhpInterpretersManagerImpl.getInstance(project).findInterpreterById(e.getInterpreterId()):null;
         } catch (QualityToolValidationException var3) {
             return null;
         }


### PR DESCRIPTION
Now the plugin is compatible with at least last 2017.3 and 2018.1 API

IDE Fatal Error #2 is resolved by the changes.